### PR TITLE
Fix so background audio from other apps can play when disableFocus is…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Changelog
 
 ### next
-
+* Fix Android videos being able to play with background music/audio from other apps.
 * Fix loading package resolved videos when using video-caching [#1438](https://github.com/react-native-community/react-native-video/pull/1438)
 
 ### Version 4.3.0

--- a/README.md
+++ b/README.md
@@ -363,6 +363,13 @@ Controls are not available Android because the system does not provide a stock s
 
 Platforms: iOS, react-native-dom
 
+#### disableFocus
+Determines whether video audio should override background music/audio in Android devices.
+* ** false (default)** - Override background audio/music
+* **true** - Let background audio/music from other apps play
+
+Platforms: Android Exoplayer
+
 #### filter
 Add video filter
 * **FilterType.NONE (default)** - No Filter

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -366,7 +366,7 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     private boolean requestAudioFocus() {
-        if (disableFocus) {
+        if (disableFocus || srcUri == null) {
             return true;
         }
         int result = audioManager.requestAudioFocus(this,


### PR DESCRIPTION
… true. requestAudioFocus was being run regardless of there being a src, so I made it so that only gets requested when a src exists.

#### Provide an example of how to test the change
Test by playing music from a different app. Letting it play in the background, and open your app with different videos set to "disableFocus" true and false on different views in your app on an Android device. You will notice that the videos with true will allow the background music to play, while the ones set to false will stop the background music.

#### Describe the changes
This PR makes it so the requestAudioFocus method never gets called before the props get set from the react native component. I noticed that the disableFocus was false at first and would change to true, so I thought it best to also stop it if there was no srcUri as well.
